### PR TITLE
Improve connection wrapping

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -24,6 +24,9 @@ func Wrap(cn net.Conn) (net.Conn, error) {
 	return c, nil
 }
 
+// Conn is an implementation of net.Conn interface for TCP connections that come
+// from a proxy that users the Proxy Protocol to communicate with the upstream
+// servers.
 type Conn struct {
 	net.Conn
 	r       *bufio.Reader
@@ -32,8 +35,10 @@ type Conn struct {
 	proxied bool
 }
 
+// ProxyAddr returns the proxy remote network address.
 func (c *Conn) ProxyAddr() net.Addr { return c.proxy }
 
+// RemoteAddr returns the remote network address.
 func (c *Conn) RemoteAddr() net.Addr {
 	if c.remote != nil {
 		return c.remote
@@ -41,6 +46,7 @@ func (c *Conn) RemoteAddr() net.Addr {
 	return c.Conn.RemoteAddr()
 }
 
+// Read reads data from the connection.
 func (c *Conn) Read(b []byte) (int, error) { return c.r.Read(b) }
 
 func (c *Conn) init() error {

--- a/conn.go
+++ b/conn.go
@@ -33,7 +33,6 @@ type conn struct {
 	proxied bool
 }
 
-func (c *conn) LocalAddr() net.Addr  { return c.local }
 func (c *conn) RemoteAddr() net.Addr { return c.remote }
 
 func (c *conn) Read(b []byte) (int, error) { return c.r.Read(b) }

--- a/conn.go
+++ b/conn.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-	"time"
 )
 
 // ErrInvalidProxyProtocolHeader is the error returned by Wrap when the proxy
@@ -19,7 +18,7 @@ var ErrInvalidProxyProtocolHeader = errors.New("invalid proxy protocol header")
 // properly identify the remote address if it comes via a proxy that
 // supports the Proxy Protocol.
 func Wrap(cn net.Conn) (net.Conn, error) {
-	c := &conn{cn: cn, r: bufio.NewReader(cn)}
+	c := &conn{Conn: cn, r: bufio.NewReader(cn)}
 	if err := c.init(); err != nil {
 		return nil, err
 	}
@@ -27,19 +26,12 @@ func Wrap(cn net.Conn) (net.Conn, error) {
 }
 
 type conn struct {
-	cn      net.Conn
+	net.Conn
 	r       *bufio.Reader
 	local   net.Addr
 	remote  net.Addr
 	proxied bool
 }
-
-func (c *conn) Close() error                { return c.cn.Close() }
-func (c *conn) Write(b []byte) (int, error) { return c.cn.Write(b) }
-
-func (c *conn) SetDeadline(t time.Time) error      { return c.cn.SetDeadline(t) }
-func (c *conn) SetReadDeadline(t time.Time) error  { return c.cn.SetReadDeadline(t) }
-func (c *conn) SetWriteDeadline(t time.Time) error { return c.cn.SetWriteDeadline(t) }
 
 func (c *conn) LocalAddr() net.Addr  { return c.local }
 func (c *conn) RemoteAddr() net.Addr { return c.remote }
@@ -47,8 +39,8 @@ func (c *conn) RemoteAddr() net.Addr { return c.remote }
 func (c *conn) Read(b []byte) (int, error) { return c.r.Read(b) }
 
 func (c *conn) init() error {
-	c.local = c.cn.LocalAddr()
-	c.remote = c.cn.RemoteAddr()
+	c.local = c.Conn.LocalAddr()
+	c.remote = c.Conn.RemoteAddr()
 
 	buf, err := c.r.Peek(6)
 	if err != io.EOF && err != nil {

--- a/conn.go
+++ b/conn.go
@@ -56,8 +56,8 @@ func (c *Conn) init() error {
 		return errors.Wrap(err, "parsing proxy protocol header")
 	}
 	if bytes.Equal(buf, unknown) {
-		c.r.Discard(len(unknown))
-		return nil
+		_, err = c.r.Discard(len(unknown))
+		return err
 	}
 
 	// PROXY

--- a/conn.go
+++ b/conn.go
@@ -28,17 +28,18 @@ func Wrap(cn net.Conn) (net.Conn, error) {
 type conn struct {
 	net.Conn
 	r       *bufio.Reader
-	local   net.Addr
+	proxy   net.Addr
 	remote  net.Addr
 	proxied bool
 }
 
+func (c *conn) ProxyAddr() net.Addr  { return c.proxy }
 func (c *conn) RemoteAddr() net.Addr { return c.remote }
 
 func (c *conn) Read(b []byte) (int, error) { return c.r.Read(b) }
 
 func (c *conn) init() error {
-	c.local = c.Conn.LocalAddr()
+	c.proxy = c.Conn.LocalAddr()
 	c.remote = c.Conn.RemoteAddr()
 
 	buf, err := c.r.Peek(6)
@@ -82,7 +83,7 @@ func (c *conn) init() error {
 	}
 
 	c.remote = &net.TCPAddr{IP: clientIP, Port: clientPort}
-	c.local = &net.TCPAddr{IP: proxyIP, Port: proxyPort}
+	c.proxy = &net.TCPAddr{IP: proxyIP, Port: proxyPort}
 
 	return nil
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
+	"log"
 	"net"
 	"testing"
 
@@ -90,5 +91,31 @@ func TestWrap(t *testing.T) {
 				t.Errorf("expecting ProxyAddr() %v, got %v", c.proxy, pcn.ProxyAddr())
 			}
 		})
+	}
+}
+
+func Example() {
+	// Listen on TCP port 8080 for connections coming from a proxy that sends
+	// the Proxy Protocol header.
+	l, err := viaproxy.Listen("tcp", ":8080")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer l.Close()
+
+	for {
+		// Wait for a connection.
+		conn, err := l.Accept()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// The connection should be safe to be converted to a *viaproxy.Conn
+		// structure.
+		cn := conn.(*viaproxy.Conn)
+		log.Printf("remote address is: %v", cn.RemoteAddr())
+		log.Printf("local address is: %v", cn.LocalAddr())
+		log.Printf("proxy address is: %v", cn.ProxyAddr())
+		cn.Close()
 	}
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,0 +1,80 @@
+package viaproxy_test
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net"
+	"testing"
+
+	"github.com/inkel/viaproxy"
+)
+
+type conn struct {
+	net.Conn
+	data io.Reader
+}
+
+func (c *conn) Read(b []byte) (n int, err error) { return c.data.Read(b) }
+
+func (c *conn) LocalAddr() net.Addr  { return &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 9876} }
+func (c *conn) RemoteAddr() net.Addr { return &net.TCPAddr{IP: net.ParseIP("10.0.1.2"), Port: 1234} }
+
+func testConn(data []byte) net.Conn { return &conn{data: bytes.NewReader(data)} }
+
+type testAddr string
+
+func (a testAddr) Network() string { return "tcp" }
+func (a testAddr) String() string  { return string(a) }
+
+func equalAddr(a, b net.Addr) bool {
+	return a.Network() == b.Network() && a.String() == b.String()
+}
+func TestWrap(t *testing.T) {
+	cases := []struct {
+		line, data []byte
+		remoteAddr testAddr
+		err        error
+	}{
+		{[]byte("PROXY TCP4 192.168.1.20 10.0.0.1 5678 1234\r\nfoo\r\nbar\r\n"), []byte("foo\r\nbar\r\n"), "192.168.1.20:5678", nil},
+		{[]byte("PROXY UNKNOWN\r\nfoo\r\nbar\r\n"), []byte("foo\r\nbar\r\n"), "10.0.1.2:1234", nil},
+
+		{[]byte("foo\r\nbar\r\n"), []byte("foo\r\nbar\r\n"), "10.0.1.2:1234", nil},
+		{[]byte("\x00\r\n"), []byte("\x00\r\n"), "10.0.1.2:1234", nil},
+
+		// Invalid proxy protocol lines
+		{[]byte("PROXY TCP5\r\n"), nil, "", viaproxy.ErrInvalidProxyProtocolHeader},
+		{[]byte("PROXY TCP4 192.168.X.20 10.0.0.1 5678 1234\r\n"), nil, "", viaproxy.ErrInvalidProxyProtocolHeader},
+		{[]byte("PROXY TCP4 192.168.1.20 10.X.0.1 5678 1234\r\n"), nil, "", viaproxy.ErrInvalidProxyProtocolHeader},
+		{[]byte("PROXY TCP4 192.168.1.20 10.0.0.1 567X 1234\r\n"), nil, "", viaproxy.ErrInvalidProxyProtocolHeader},
+		{[]byte("PROXY TCP4 192.168.1.20 10.0.0.1 5678 123X\r\n"), nil, "", viaproxy.ErrInvalidProxyProtocolHeader},
+	}
+
+	for _, c := range cases {
+		t.Run(string(c.line), func(t *testing.T) {
+			cn := testConn(c.line)
+
+			cn, err := viaproxy.Wrap(cn)
+			if err != c.err {
+				t.Fatalf("expecting error %v, got %v", c.err, err)
+			}
+			if cn == nil && c.err != nil {
+				// no need to continue processing
+				return
+			}
+
+			if !equalAddr(c.remoteAddr, cn.RemoteAddr()) {
+				t.Errorf("expecting RemoteAddr() %v, got %v", c.remoteAddr, cn.RemoteAddr())
+			}
+
+			data, err := ioutil.ReadAll(cn)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(c.data, data) {
+				t.Errorf("expecting data %q, got %q", c.data, data)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request refactors the package extensively. The biggest changes are the addition of tests (finally) and exporting the `Conn` structure. This has the additional benefit that now `viaproxy.Conn` exports a `ProxyAddr` method in addition to `LocalAddr` and `RemoteAddr` that provides more information about the addresses of the connection.

It also improves reading the Proxy Protocol line. Error management is improving, though is still far from what I'd like to have.

This pull request aims to address most (if not) the issues listed in #1.