### PR TITLE
Return concrete types instead of interfaces

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -29,11 +29,10 @@ func Wrap(cn net.Conn) (*Conn, error) {
 // from a proxy that users the Proxy Protocol to communicate with the upstream
 // servers.
 type Conn struct {
-	cn      net.Conn
-	r       *bufio.Reader
-	proxy   net.Addr
-	remote  net.Addr
-	proxied bool
+	cn     net.Conn
+	r      *bufio.Reader
+	proxy  net.Addr
+	remote net.Addr
 }
 
 // ProxyAddr returns the proxy remote network address.

--- a/conn.go
+++ b/conn.go
@@ -13,10 +13,10 @@ import (
 // protocol header is malformed.
 var ErrInvalidProxyProtocolHeader = errors.New("invalid proxy protocol header")
 
-// Wrap takes a net.Conn and returns a net.Conn that knows how to
+// Wrap takes a net.Conn and returns a pointer to Conn that knows how to
 // properly identify the remote address if it comes via a proxy that
 // supports the Proxy Protocol.
-func Wrap(cn net.Conn) (net.Conn, error) {
+func Wrap(cn net.Conn) (*Conn, error) {
 	c := &Conn{Conn: cn, r: bufio.NewReader(cn)}
 	if err := c.init(); err != nil {
 		return nil, err

--- a/conn_test.go
+++ b/conn_test.go
@@ -55,9 +55,7 @@ func TestWrap(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(string(c.line), func(t *testing.T) {
-			cn := testConn(c.line)
-
-			cn, err := viaproxy.Wrap(cn)
+			cn, err := viaproxy.Wrap(testConn(c.line))
 			if c.err && err == nil {
 				t.Fatal("expecting error, got nil")
 			}
@@ -83,12 +81,8 @@ func TestWrap(t *testing.T) {
 				t.Errorf("expecting data %q, got %q", c.data, data)
 			}
 
-			pcn, ok := cn.(*viaproxy.Conn)
-			if !ok {
-				t.Fatalf("cannot cast connection to *viaproxy.Conn")
-			}
-			if !equalAddr(pcn.ProxyAddr(), c.proxy) {
-				t.Errorf("expecting ProxyAddr() %v, got %v", c.proxy, pcn.ProxyAddr())
+			if !equalAddr(cn.ProxyAddr(), c.proxy) {
+				t.Errorf("expecting ProxyAddr() %v, got %v", c.proxy, cn.ProxyAddr())
 			}
 		})
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -137,3 +137,30 @@ func ExampleListener_AcceptFromProxy() {
 	}
 }
 
+func ExampleWrap() {
+	// Listen on TCP port 8080 for connections coming from a proxy that sends
+	// the Proxy Protocol header.
+	l, err := net.Listen("tcp", ":8080")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer l.Close()
+
+	for {
+		// Wait for a connection.
+		cn, err := l.Accept()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		pcn, err := viaproxy.Wrap(cn)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		log.Printf("remote address is: %v", pcn.RemoteAddr())
+		log.Printf("local address is: %v", pcn.LocalAddr())
+		log.Printf("proxy address is: %v", pcn.ProxyAddr())
+		pcn.Close()
+	}
+}

--- a/conn_test.go
+++ b/conn_test.go
@@ -88,7 +88,7 @@ func TestWrap(t *testing.T) {
 	}
 }
 
-func Example() {
+func ExampleListener_Accept() {
 	// Listen on TCP port 8080 for connections coming from a proxy that sends
 	// the Proxy Protocol header.
 	l, err := viaproxy.Listen("tcp", ":8080")
@@ -113,3 +113,27 @@ func Example() {
 		cn.Close()
 	}
 }
+
+func ExampleListener_AcceptFromProxy() {
+	// Listen on TCP port 8080 for connections coming from a proxy that sends
+	// the Proxy Protocol header.
+	l, err := viaproxy.Listen("tcp", ":8080")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer l.Close()
+
+	for {
+		// Wait for a connection.
+		cn, err := l.AcceptFromProxy()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		log.Printf("remote address is: %v", cn.RemoteAddr())
+		log.Printf("local address is: %v", cn.LocalAddr())
+		log.Printf("proxy address is: %v", cn.ProxyAddr())
+		cn.Close()
+	}
+}
+


### PR DESCRIPTION
This is more idiomatic in Go. Also it saves the caller the need to typecast the returned object of calling [`viaproxy.Wrap`](https://godoc.org/github.com/inkel/viaproxy#Wrap) to a [`viaproxy.Conn`](https://godoc.org/github.com/inkel/viaproxy#Conn) and thus giving automatically access to methods like [`ProxyAddr`](https://godoc.org/github.com/inkel/viaproxy#Conn.ProxyAddr). And given that `viaproxy.Conn` implements the [`net.Conn`](https://golang.org/pkg/net/#Conn) interface, it can be passed as an argument to any other methods that accept a [`net.Conn`](https://golang.org/pkg/net/#Conn).